### PR TITLE
Bump build_runner to 2.0.4

### DIFF
--- a/builders/json_serializable_immutable_collections/pubspec.yaml
+++ b/builders/json_serializable_immutable_collections/pubspec.yaml
@@ -13,7 +13,7 @@ dev_dependencies:
 
 dependencies:
   json_serializable:  ">=4.1.0 <5.0.0"
-  build_runner: ^1.11.0
+  build_runner: ^2.0.4
   source_gen: "^1.0.0"
   analyzer: "^1.0.0"
   build: ^2.0.0


### PR DESCRIPTION
Required for me as my project uses the latest version of build_runner