### PR TITLE
[json_serializable_mobx] Bump dependency versions for build_runner

### DIFF
--- a/builders/json_serializable_mobx/CHANGELOG.md
+++ b/builders/json_serializable_mobx/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.0
+- bump dependencies for build_runner to be compatible with latest packages
+
 ## 0.6.0
 
 - major internal changes. break up into builders and type helper packages

--- a/builders/json_serializable_mobx/pubspec.yaml
+++ b/builders/json_serializable_mobx/pubspec.yaml
@@ -1,6 +1,6 @@
 name: json_serializable_mobx
 description: Adding support for mobx collections for json_serializable
-version: 0.6.0
+version: 0.7.0
 homepage: https://github.com/knaeckeKami/immutable_json_list_serializer
 
 environment:
@@ -8,13 +8,13 @@ environment:
 
 dev_dependencies:
   test: ^1.16.8
-  mobx: ^2.0.0-nullsafety.5
+  mobx: ^2.0.1
 
 dependencies:
-  json_serializable:  ^4.1.0
-  build_runner: ^1.11.0
-  analyzer: ^1.0.0
-  source_gen: ^1.0.0
+  json_serializable:  ^4.1.3
+  build_runner: ^2.0.5
+  analyzer: ^1.7.1
+  source_gen: ^1.0.2
   build: ^2.0.0
   json_serializable_mobx_typehelpers: ^1.0.0
   json_annotation: ^4.0.1


### PR DESCRIPTION
Adds support for latest build_runner.